### PR TITLE
Update 3_mpi.jl

### DIFF
--- a/Lectures/3_mpi.jl
+++ b/Lectures/3_mpi.jl
@@ -420,8 +420,8 @@ Foldable(
 	md"Can `MPI_Allreduce` be implemented by combining existing collectives ?",
 	md"""
 Let the size of each ``x_i`` be ``n`` bytes. `MPI_Allreduce` can be implemented either by combining `MPI_Reduce` followed by `MPI_Bcast` or `MPI_Reduce_scatter` followed by `MPI_Allgather`.
-The first choice would lead to a complexity of ``\log_2(p)(\alpha + \beta n)``
-The second would lead to a complexity of ``\log_2(p)\alpha + \beta n``.
+The first choice would lead to a complexity of ``\log_2(p)(\alpha + \beta n + \gamma n )``
+The second would lead to a complexity of ``\log_2(p)\alpha + \beta n + \gamma n``.
 """,
 )
 


### PR DESCRIPTION
It seems to me that in all reduce we should also take the cost of the arithmetic operations into account. It is the only reduce operation where gamma does not appear, which does not make sense to me