### PR TITLE
Update 3_mpi.jl

### DIFF
--- a/Lectures/3_mpi.jl
+++ b/Lectures/3_mpi.jl
@@ -250,7 +250,7 @@ hbox([
 # ╔═╡ db16e939-b490-497b-a03f-80ce2e8485af
 Foldable(
 	md"Lower bound complexity with ``p`` processes if each ``x_i`` has length $n$ bytes and the arithmetic complexity is ``\gamma`` ?",
-	md"""Lower bound : ``\log_2(p) (\alpha + \beta n) + \log_2(p) \gamma n`` using *spanning tree* algorithm:
+	md"""Lower bound : ``\log_2(p) \alpha + \beta n + \log_2(p) \gamma n`` using *spanning tree* algorithm:
 
 First communication (2 → 1 and 4 → 3 at the same time):
 

--- a/Lectures/3_mpi.jl
+++ b/Lectures/3_mpi.jl
@@ -152,7 +152,7 @@ hbox([
 # ╔═╡ 5d72bf87-7f3a-4229-9d7a-2e63c115087d
 Foldable(
 	md"Lower bound complexity with ``p`` processes if ``x`` has  length ``n`` bytes ?",
-	md"""Lower bound : ``\log_2(p) (\alpha + \beta n)`` using *spanning tree* algorithm:
+	md"""Lower bound : ``\log_2(p) \alpha + \beta n`` using *spanning tree* algorithm:
 
 After first communication (1 → 3):
 


### PR DESCRIPTION
I think there is a mistake : the spanning tree algorithm should not worsen the fixed cost, no?

edit : according to wikipedia, "Pipelined broadcast on balanced binary is possible in 
O(α log p + βn) whereas for the non-pipelined case it takes O((α+βn)log p) cost. "
https://en.wikipedia.org/wiki/Collective_operation
so i'm a bit confused