### PR TITLE
Fix typos in bw(S,T) sum condition and argument

### DIFF
--- a/Lectures/3_mpi.jl
+++ b/Lectures/3_mpi.jl
@@ -644,7 +644,7 @@ or 0 otherwise. Given ``S, T \subseteq V``,
 ```math
 \begin{align}
 \text{Width} &\qquad &  w(S, T) & = |\{ (u, v) \in E \mid u \in S, v \in T \}|\\
-\text{Bandwidth} & & \texttt{bw}(S, T) & = \sum_{u\in S, v\in T} w(u,v)
+\text{Bandwidth} & & \texttt{bw}(S, T) & = \sum_{u\in S, v\in T} \texttt{bw}(u,v)
 \end{align}
 ```
 """

--- a/Lectures/3_mpi.jl
+++ b/Lectures/3_mpi.jl
@@ -644,7 +644,7 @@ or 0 otherwise. Given ``S, T \subseteq V``,
 ```math
 \begin{align}
 \text{Width} &\qquad &  w(S, T) & = |\{ (u, v) \in E \mid u \in S, v \in T \}|\\
-\text{Bandwidth} & & \texttt{bw}(S, T) & = \sum_{u\in S, v\not\in S} w(u,v)
+\text{Bandwidth} & & \texttt{bw}(S, T) & = \sum_{u\in S, v\in T} w(u,v)
 \end{align}
 ```
 """


### PR DESCRIPTION
In the general definition of bw(S,T), the sum is written over u \in S, v \not\in S, which makes the parameter T completely unused in the formula body. It should be v \in T to match the signature bw(S,T). The special case where T = V\S (used for bisection bandwidth) makes v \in T equivalent to v \not\in S, which is likely the source of the confusion.

Another potential problem is that w(u,v) in the sum of bw(S,T) refers to the bandwidth (weight) of a single edge, while w(S,T) defined just above refers to the width (cardinality of edges between them), yet both use the same letter w. A different notation for the argument of the sum, such as bw(u,v) for the edge weight as defined right above for this purpose, might avoid confusion.