### PR TITLE
Typos fix in lecture notes

### DIFF
--- a/Exams/2025_08/q4.tex
+++ b/Exams/2025_08/q4.tex
@@ -48,14 +48,14 @@ and $z$ be the number of nonzero entries in the whole sparse matrix.
             where
             \begin{itemize}
             \item the first $\alpha + \beta n$ is for broadcasting the input vector of length $n$ (assuming node one can send the data to all other nodes in parallel since it has distinct connections to each node),
-            \item $\gamma (z / d + n)$ is the total computation time for $z$ nonzeros, if $d$ is large and gets close to $z$, the number of nonzeros per node is small but we still need to iterate through \texttt{colptr} which has length $m$ so we need to use $z/d + m$ not just $z/d$,
-            \item and the second $\alpha + \beta m/d$ is for gathering the result vector of size $n$.
+            \item $\gamma (z / d + n)$ is the total computation time for $z$ nonzeros, if $d$ is large and gets close to $z$, the number of nonzeros per node is small but we still need to iterate through \texttt{colptr} which has length $n$ so we need to use $z/d + n$ not just $z/d$,
+            \item and the second $\alpha + \beta m/d$ is for gathering the result vector of size $m$.
             \end{itemize}
 
             For the \textbf{tree topology} (column-wise partitioning),
             the time complexity is:
             \[
-                T_{\text{tree}} = \mathcal{O}(\alpha \log_2 d + \beta (n/2 + n/4 + n/8 + \cdots) + \gamma (z + n) / d + (\alpha + \beta m) \log_2 d)
+                T_{\text{tree}} = \mathcal{O}(\alpha \log_2 d + \beta (n/2 + n/4 + n/8 + \cdots) + \gamma (z + n) / d + (\alpha + \beta m + \gamma m) \log_2 d)
             \]
             where
             \begin{itemize}
@@ -64,7 +64,7 @@ and $z$ be the number of nonzero entries in the whole sparse matrix.
                 Then each child communicate half of the vector so length $n/4$ etc...
                 In total, we have a sum of $\mathcal{O}(n/2 + n/4 + n/8 + \cdots) = \mathcal{O}(n)$.
                 \item $\gamma (z + n) / d$ is the computation. In case the matrix is super sparse and $z \ll n$, we still need to iterate over \texttt{colptr} so we need $z + n$.
-                \item $(\alpha + \beta n) \log_2 d$ is for the communication of the result vector. This time, each communication is with the full result of length $m$.
+                \item $(\alpha + \beta m + \gamma m) \log_2 d$ is for the reducing procedure of the result vector. This time, each communication is with the full result of length $m$ and we have to sum the partial result vectors of length $m$ at each level of the tree.
             \end{itemize}
         \end{solutionbox}
 \end{parts}

--- a/Lectures/1_simd.jl
+++ b/Lectures/1_simd.jl
@@ -95,7 +95,7 @@ md"## Faster Julia code"
 
 # ╔═╡ f853de2d-ca27-42d6-af9a-194ee6bb7d89
 Foldable(md"How to get the same speed up from the Julia code ?", md"
-* The `-O3` option need to be passed to the `julia` session that started Pluto, `-O2` is used by default.
+* The `-O3` option needs to be passed to the `julia` session that started Pluto, `-O2` is used by default.
 * Instead of applying `-fast-math` to the whole library, the macro `@fastmath` allows to apply it to a selected part of the code.
 * In order to accurately throw the out of bound error for the **first** index that is out of bound, Julia will prevent SIMD to be applied. The bound checking also makes it harder to parallelise. To circumvent this, check the bounds outside of the loop and then use `@inbounds` to disable bound checks inside the loop.
 * The use of SIMD can also be forced with `@simd`.")
@@ -128,7 +128,7 @@ end
 md"## Careful with fast math"
 
 # ╔═╡ b19154d8-cb88-4aac-b76a-18f647672d70
-Foldable(md"Why are the three elements in the center of the vector ignored in this example ?", md"In a large sum, the `total` variable becomes much larger than each summand. Because of this, significant roundoff errors can occur. These roundoff errors cannot be added to the `total` variable as it is too large but it may be added to the summands as they are smaller so as to compensate the error. Here, instead of considering a large sum, we just used a large first summand to simplify but you can consider `1` as being the sum of a large amounts of preceding elements in the sum to make it more realistic.")
+Foldable(md"Why are the three elements in the center of the vector ignored in this example ?", md"In a large sum, the `total` variable becomes much larger than each summand. Because of this, significant roundoff errors can occur. These roundoff errors cannot be added to the `total` variable as it is too large but they may be added to the summands as they are smaller so as to compensate the error. Here, instead of considering a large sum, we just used a large first summand to simplify but you can consider `1` as being the sum of a large amount of preceding elements in the sum to make it more realistic.")
 
 # ╔═╡ 4cd17588-8f3c-447e-890b-fc881575db8d
 test_kahan = Cfloat[1.0, eps(Cfloat)/4, eps(Cfloat)/4, eps(Cfloat)/4, 1000eps(Cfloat)]
@@ -147,7 +147,7 @@ hbox([Div(
 )
 
 # ╔═╡ 52cd9d6e-0e24-45ae-a602-1b9d9edc67ae
-Foldable(md"What happens when `-ffast-math` is enabled ?", md"The flag allows LLVM to optimize out the code to be exactly the as the code of `c_sum`! This does not happen at `-O0`, so the optimization level also needs to be increased to see this.")
+Foldable(md"What happens when `-ffast-math` is enabled ?", md"The flag allows LLVM to optimize out the code to be exactly the same as the code of `c_sum`! This does not happen at `-O0`, so the optimization level also needs to be increased to see this.")
 
 # ╔═╡ 1a4f7389-9d1b-4008-8896-76ecc409ab1f
 md"For further details, see [this blog post](https://simonbyrne.github.io/notes/fastmath/)."
@@ -188,9 +188,9 @@ md"## Instruction sets"
 
 # ╔═╡ 1ddcda8b-fa23-4802-852c-e70b1777c2e4
 md"""
-The data is **packed** on a single SIMD unit whose width and register depends on the instruction set family.
+The data is **packed** on a single SIMD unit whose width and register depend on the instruction set family.
 The single instruction is then run in parallel on all elements of this small **vector** stored in the SIMD unit.
-These give the prefix `vp` to the instruction names that stands for *Vectorized Packed*.
+These give the prefix `vp`, which stands for *Vectorized Packed*, to the instruction names.
 
 | Instruction Set Family | Width of SIMD unit | Register |
 |-----------------|-------------------|----------|
@@ -470,9 +470,9 @@ md"## Further notes"
 
 # ╔═╡ ffb3eb82-9152-4bda-bfb3-cedecc737037
 md"""
-* Can be controlled with `#pragma clang loop interleave_count(4)` but the compiler usually already does a good job choosing the `interleave_count`
+* Can be controlled with `#pragma clang loop interleave_count(4)` but the compiler usually already does a good job choosing the `interleave_count`.
 * This count depends on whether it is *compute bound* or *memory bound*, see next lecture where we discuss these.
-* The above examples assumes the value of `a[i]` etc... are in L1 cache. If not (aka "L1 cache miss"), the latency for loading `a[i]`, will be much longer.
+* The above examples assume that the value of `a[i]` etc. are in L1 cache. If not (aka "L1 cache miss"), the latency for loading `a[i]` will be much longer.
 
 Additional practical limits include:
 

--- a/Lectures/2_shared.jl
+++ b/Lectures/2_shared.jl
@@ -190,7 +190,7 @@ begin
 	no_diff = Foldable(
 		md"Wait, these didn't make any difference in the benchmark, how can it be ?",
 		md"""
-The compiler most probably use a register (actually a SIMD register here (if there is any) since we used `#pragma omp simd`) as accumulator for the `for` loop and only stored the value of that register into `total`, `local_results[thread_num]` or `no_false_sharing` (depending on the version).
+The compiler most probably uses a register (actually a SIMD register here (if there is any) since we used `#pragma omp simd`) as accumulator for the `for` loop and only stored the value of that register into `total`, `local_results[thread_num]` or `no_false_sharing` (depending on the version).
 Despite all this, it is still important to be careful about this issue and not trust the execution on one environment or rely too much on compiler optimizations for the code to be portable.
 """,
 	)

--- a/Lectures/3_mpi.jl
+++ b/Lectures/3_mpi.jl
@@ -206,7 +206,7 @@ hbox([
 Foldable(
 	md"Lower bound complexity with ``p`` processes if each ``x_i`` has length ``n/p`` bytes ?",
 	md"""
-Lower bound : ``\log_2(p) \alpha`` using *spanning tree* algorithm and ``\beta n`` as all message need to sent at least once. *spanning tree* is advantageous if ``\alpha`` is larger than ``\beta`` and direct to `1` if otherwise. In practice, you want a mix of both.
+Lower bound : ``\log_2(p) \alpha`` using *spanning tree* algorithm and ``\beta n`` as all messages need to be sent at least once. *spanning tree* is advantageous if ``\alpha`` is larger than ``\beta`` and *direct to `1`* is preferable otherwise. In practice, you want a mix of both.
 
 First send ``x_2`` from 2 to 1 and simultaneously send ``x_4`` from 4 to 3.
 Complexity is ``\alpha + \beta n/4``
@@ -463,7 +463,7 @@ md"## Blocking communication"
 md"""
 Blocking send/received with `MPI_Send` and `MPI_Recv`.
 
-The network cannot buffer the whole message (unless it is short). The sender need to wait for the receiver to be ready and then transfer its copy of the data.
+The network cannot buffer the whole message (unless it is short). The sender needs to wait for the receiver to be ready and then transfers its copy of the data.
 """
 
 # ╔═╡ 34a10003-2c32-4332-b3e6-ce70eec0cbbe
@@ -656,13 +656,14 @@ md"## Bisection bandwidth"
 # ╔═╡ 1b617828-e2b2-4a94-a120-59fa533d3e11
 md"""
 Bandwidth ``\texttt{bw}(u, v)`` is the bandwidth of the cable if ``(u, v) \in E``
-or 0 otherwise. Given ``S, T \subseteq V``,
+or 0 otherwise. Given ``S, T \subseteq V`` two disjoint subsets of nodes ``S \cap T = \varnothing``,
 ```math
 \begin{align}
 \text{Width} &\qquad &  w(S, T) & = |\{ (u, v) \in E \mid u \in S, v \in T \}|\\
 \text{Bandwidth} & & \texttt{bw}(S, T) & = \sum_{u\in S, v\in T} \texttt{bw}(u,v)
 \end{align}
 ```
+The width is exactly the number of edges between the two sets of nodes.
 """
 
 # ╔═╡ f2ebc6fb-e07c-4922-897d-9bbe0f5fa1d0
@@ -684,7 +685,7 @@ The *bisection **band**width* is:
 # ╔═╡ 8da580fe-6b56-4d8f-ad43-aed7b728a06e
 md"""
 * Worst case pairwise communication of two groups ``S`` and ``V \setminus S`` of *almost* (``\pm 1``) equal size.
-* NP-hard to compute for general graphs
+* NP-hard to compute for general graphs.
 """
 
 # ╔═╡ fa024a5d-52a6-459d-894d-13a60ec723d2
@@ -777,7 +778,7 @@ Foldable(md"What are the number of switches, edges, graph diameter and bisection
 md"""
 * There are ``n^2`` switches one per intersection. This makes this architecture only suitable for small ``n``.
 * The number of edges is : ``|E| = 2n^2`` which consists of ``n`` connections from an input to a switch, ``n`` connections from a switch to an output and ``2n(n-1)`` connections between switches.
-* The diameter 2 if we don't count the in-between switches or ``2n`` if we coun't them.
+* The diameter is 2 if we don't count the in-between switches or ``2n`` if we count them.
 * The bisection width is ``n/2``.
 """)
 
@@ -836,7 +837,7 @@ aside(citeintro("Section 2.7.6.3"), v_offset = -150)
 md"## Butterfly"
 
 # ╔═╡ f7f097cb-d7bd-49eb-a030-ac26f8f61a67
-md"Fat-tree need large switches, the root one of previous slide had 8 links. This is as many links as the number of processes, that's not scalable. An alternative is butterfly network for which each switch uses at most 4 links. In the figures above, the boxes with `P` represent a process, the ones with `M` respresent their local memory and the other ones are the routers."
+md"Fat-tree needs large switches, the root one of previous slide had 8 links. This is as many links as the number of processes, that's not scalable. An alternative is butterfly network for which each switch uses at most 4 links. In the figures above, the boxes with `P` represent a process, the ones with `M` represent their local memory and the other ones are the routers."
 
 # ╔═╡ 6041a909-d26c-4ab1-836b-29953c578759
 Foldable(md"What is the number of edges ? What is the bisection width ?",
@@ -1033,8 +1034,8 @@ img1(f, args...) = img("https://raw.githubusercontent.com/VictorEijkhout/TheArtO
 # ╔═╡ 133f4c7d-33e0-4e13-b716-f538125436ca
 TwoColumnWideLeft(
 md"""
-There can be ``n`` simultaneous communication at the same time, provided that each input communicate with a different output.
-The figure on the right provides an example of such non-conflicting communication with the black dots indicating that the input of that row communicates to the corresponding output (case (a) of above figure). The switch at row 1 and column 2 is just propagating the input data horizontally and output data vertically (case (b) of above figure). The switch at row 0 and column 5 is receiving no data.
+There can be ``n`` simultaneous communications at the same time, provided that each input communicates with a different output.
+The figure on the right provides an example of such non-conflicting communications with the black dots indicating that the input of that row communicates to the corresponding output (case (a) of above figure). The switch at row 1 and column 2 is just propagating the input data horizontally and output data vertically (case (b) of above figure). The switch at row 0 and column 5 is receiving no data.
 """,
 img1("crossbar.jpg"),
 )

--- a/Lectures/4_gpu.jl
+++ b/Lectures/4_gpu.jl
@@ -90,7 +90,7 @@ OpenCL.versioninfo()
 md"See also `clinfo` command line tool and `examples/OpenCL/common/device_info.c`."
 
 # ╔═╡ b8f2ae64-8e2a-4ac3-9635-4761077cb834
-aside(tip(Foldable(md"tl;dr To refresh the list of platforms, you need to quit Julia and open a new session", md"The OpenCL ICD Loader will compute the list of available platforms once the first time it is needed and it will never recompute it again. You can indeed see [here](https://github.com/KhronosGroup/OpenCL-ICD-Loader/blob/d547426c32f9af274ec1369acd1adcfd8fe0ee40/loader/linux/icd_linux.c#L234-L238) it it sets a global `initialized` variable to `true`. This means that, if you do `using pocl_jll` or install the required GPU drivers and look at the list of platforms again from the same Julia sessions, you won't see any changes! There is unfortunately no way to set this `initialized` variable back to `false` so you'll need to restart Julia and make sure you do `using pocl_jll` before using OpenCL. Fortunately, Pluto does this in the right order.")), v_offset = -400)
+aside(tip(Foldable(md"tl;dr To refresh the list of platforms, you need to quit Julia and open a new session", md"The OpenCL ICD Loader will compute the list of available platforms once the first time it is needed and it will never recompute it again. You can indeed see [here](https://github.com/KhronosGroup/OpenCL-ICD-Loader/blob/d547426c32f9af274ec1369acd1adcfd8fe0ee40/loader/linux/icd_linux.c#L234-L238) that it sets a global `initialized` variable to `true`. This means that, if you do `using pocl_jll` or install the required GPU drivers and look at the list of platforms again from the same Julia sessions, you won't see any changes! There is unfortunately no way to set this `initialized` variable back to `false` so you'll need to restart Julia and make sure you do `using pocl_jll` before using OpenCL. Fortunately, Pluto does this in the right order.")), v_offset = -400)
 
 # ╔═╡ 7c6a4307-610b-461e-b63a-e1b10fade204
 md"## Important stats"
@@ -216,7 +216,7 @@ md"# Reduction on GPU"
 md"""
 Many operations can be framed in terms of a [MapReduce](https://en.wikipedia.org/wiki/MapReduce) operation.
 * Given a vector of data
-* It first map each elements through a given function
+* It first maps each element through a given function
 * It then reduces the results into a single element
 
 The mapping part is easily embarassingly parallel but the reduction is harder to parallelize. Let's see how this reduction step can be achieved using arguably the simplest example of `mapreduce`, the sum (corresponding to an identity map and a reduction with `+`).
@@ -273,7 +273,7 @@ md"""
 * AMD wavefront : width of 64 threads
 * In general : [`CL_KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTIPLE`](https://registry.khronos.org/OpenCL/sdk/3.0/docs/man/html/clGetKernelWorkGroupInfo.html)
 * Consecutive `get_local_id()` starting from 0
-  - So the thread of local id from 0 to 31 are in the same CUDA warp.
+  - So the threads of local id from 0 to 31 are in the same CUDA warp.
 * Threads execute the **same instruction** at the same time so no need for `barrier`.
 """
 
@@ -735,7 +735,7 @@ local_sum(global_len, local_len, local_code, local_device)
 
 # ╔═╡ 9195adff-cc5d-4504-9a31-ba19b18639a0
 Foldable(
-	md"How to compute the sum an array in **local** memory with a kernel ?",
+	md"How to compute the sum of the elements of an array in **local** memory with a kernel ?",
 	codesnippet(local_code),
 )
 


### PR DESCRIPTION
This is a collection of all the typos I have found so far together with some clarifying suggestions.

1. Various typos have been fixed.

2. I would like to report that the cache file ``electricity-ghg-2024-chart.png?itok=Is4AR6wp`` is the source of issues for windows-based users of git, due to the illegal "?" character in the filename. It is currently impossible to clone the repository from the Windows PowerShell (you must be on Linux or trick your system by cloning the repo via WSL instead of the PowerShell and then delete the troublesome file.)

3. In the chapter MPI, for the bisection bandwidth subsection, the condition of disjointness of the sets has been added in the definitions. 
While the definitions of the total width and bandwidth are still valid when S and T overlap, the physical meaning becomes more difficult to grasp and the width does not link to the number of edges between the two sets anymore (because of the overlap, any edge between nodes that are shared by S and T is part of the width set), which confused me a lot during my first reading. 
I suggest here adding the mention that the sets are disjoint in the definition, to help clarify the ideas. Feel free to disregard it in case it does not align with your intentions!


5. Regarding the MPI *Gather* collective, it is written as a side note: ```*spanning tree* is advantageous if α is larger than β and *direct to 1* is preferable otherwise. In practice, you want a mix of both.``` Since what *direct to `1`* stands for wasn't entirely clear for me (I believe it hasn't been discussed in depth during the lecture), I haven't brought any proposition of modification for this part, but wanted to share my thoughts. I have discussed this with my friend @MathiasGernez and we both interpreted *direct to `1`* as :
- either a star-like topology with one central node that could communicate with all the others simultaneously (assuming we exceptionaly have a super-node that can handle multiple communications at the same time). However in this case, the complexity to gather would simply be \(α + β n/p \), which is always lower than what the tree topology achieves.
- or a naïve topology where each process can only communicate with the first one after the other to send their vector of data. This would lead to an \(α p\) fixed cost and \(p β n/p = β n\) variable cost. The total cost is therefore always worse than the tree-topology approach since \(p > \log_2(p)\). 
Neither of these interpretations seems to be correct. Perhaps the explanation behind this sidenote relies on a model that is more complex than the alpha-beta one ? We suggest the addition of a brief description of what is this *direct to `1`* paradigm for MPI.  


7. In the chapter on GPUs, for the "copy to local memory" code example, the title is a bit misleading. 
If my understanding of the kernel is correct, except when ``copy_global_len`` and ``copy_local_len`` have the same length, the kernel does not simply copy the data from the global memory but instead performs a reduction operation of the global data block-wise into the local-memory of the work group.
My suggestion would be to rename the kernel into something like "reduce_to_local" instead of "copy_to_local". 
I have not made the change to avoid breaking any code. I simply mention it here in case you find this suggestion relevant.
There is also something confusing me about the fact that if you launch this kernel with more than one work-group (global size ≠ local size), you will end up reducing in a similar fashion the data in the local memory of all the work groups. Therefore for the "sum" kernel, it appears that if you launch that kernel with more than one work-group they will each reduce the entire vector of data to their local memory and compute in parallel the exact same total summation. In the end they will all write one after the other the same final answer in the global ``*result`` pointer (though in a stochastic order, which fortunately does not matter since the work groups overwrite the result with the exact same value): the work of all the work-groups except one seems to be for nothing. 

Edit : in the meantime, I have found additional typos in the solution of the exam of August 2025. I have replaced multiple occurrences of m with n in the complexity computations for the star and tree topologies. For the star topology, since \(n\) stands for the number of columns in the matrix and therefore the size of the ``colptr`` array, the \(+ m\) term due to the iteration over the ``colptr`` array should probably be \(n\) in the explanation (similarly to what is written in the formula above). 
The final gather operation is written with complexity of \(α + β m/d\) while the explanation mentions that the result vector has size n, which seems inconsistent. I have replaced it by \(m\).
For the tree topolgy, it looks like the computation part of the reduction collective might be missing. I have added a \(+ γ m \log_2 d\) term to the formula and replaced \(+ β n \) by \(+ β m\) in the explanation for consistency with the formula above.
Hopefully my understanding is correct and I did not introduce any mistakes!

Best regards,

Mathieu Mil-Homens Cavaco
